### PR TITLE
Fix Makefile build

### DIFF
--- a/usbmuxd2/Event.hpp
+++ b/usbmuxd2/Event.hpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <atomic>
 
 class Event{
     std::mutex _m;

--- a/usbmuxd2/Makefile.am
+++ b/usbmuxd2/Makefile.am
@@ -17,10 +17,11 @@ usbmuxd_SOURCES = 	exception.cpp \
 			Device.cpp \
 			Devices/USBDevice.cpp \
 			Devices/WIFIDevice.cpp \
+			Event.cpp \
 			Manager/Manager.cpp \
 			Manager/DeviceManager/DeviceManager.cpp \
 			Manager/DeviceManager/USBDeviceManager.cpp \
-			Manager/DeviceManager/WIFIDeviceManager.cpp \
+			Manager/DeviceManager/WIFIDeviceManager-avahi.cpp \
 			Manager/ClientManager.cpp \
 			sysconf/sysconf.cpp \
 			sysconf/preflight.cpp \


### PR DESCRIPTION
There have been a few changes that, while working in the Xcode build, have broken the Makefile build.

I did not make the WifiDeviceManager implementation selectable when making these changes, as it seemed like only the Avahi implementation is available on non macOS hosts. Arguably, someone might want to use the Makefile on macOS, but it seems unlikely.