### PR TITLE
fixes compile error in debian buster on raspberrypi

### DIFF
--- a/usbmuxd2/Makefile.am
+++ b/usbmuxd2/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -I$(top_srcdir)/usbmuxd2 $(GLOBAL_CFLAGS) $(libplist_CFLAGS) $(libusb_CFLAGS) $(libimobildevice_CFLAGS) $(libgeneral_CFLAGS)
 AM_CXXFLAGS = $(GLOBAL_CXXFLAGS) $(libplist_CXXFLAGS) $(avahi_CXXFLAGS)
-AM_LDFLAGS = $(libplist_LIBS) $(libusb_LIBS) $(libimobiledevice_LIBS) $(avahi_LIBS) $(libpthread_LIBS) $(libgeneral_LIBS)
+AM_LDFLAGS = $(libplist_LIBS) $(libusb_LIBS) $(libimobiledevice_LIBS) $(avahi_LIBS) $(libpthread_LIBS) $(libgeneral_LIBS) -latomic
 
 
 sbin_PROGRAMS = usbmuxd


### PR DESCRIPTION
This fixes the compiling error when trying to build on a raspberrypi with Buster on it.  