### PR TITLE
Fix a breaking change with adding an argument to plist_from_memory

### DIFF
--- a/usbmuxd2/Client.cpp
+++ b/usbmuxd2/Client.cpp
@@ -289,7 +289,7 @@ void Client::processData(const usbmuxd_header *hdr){
                     const char *pairRecord = NULL;
                     uint64_t pairRecord_len = 0;
                     retassure(pairRecord = plist_get_data_ptr(p_pairRecord, &pairRecord_len), "Failed to get data ptr for PairRecordData");
-                    plist_from_memory(pairRecord, (uint32_t)pairRecord_len, &p_parsedPairRecord);
+                    plist_from_memory(pairRecord, (uint32_t)pairRecord_len, &p_parsedPairRecord, NULL);
                 }
                 retassure(p_parsedPairRecord, "Failed to plist-parse received PairRecordData");
 

--- a/usbmuxd2/sysconf/sysconf.cpp
+++ b/usbmuxd2/sysconf/sysconf.cpp
@@ -54,7 +54,7 @@ static plist_t readPlist(const char *filePath){
     
     {
         plist_t pl = NULL;
-        plist_from_memory(fbuf, (uint32_t)finfo.st_size, &pl);
+        plist_from_memory(fbuf, (uint32_t)finfo.st_size, &pl, NULL);
         retassure(pl, "failed to parse plist at path '%s'",filePath);        
         return pl;
     }


### PR DESCRIPTION
commit where this happens: libimobiledevice/libplist@ce9ce43efd707a85cc792ff2cc417603a53d4d1d