### PR TITLE
[BUGFIX] include ‘algorithms‘ in Muxer.cpp for clang-19

### DIFF
--- a/usbmuxd2/Muxer.cpp
+++ b/usbmuxd2/Muxer.cpp
@@ -27,6 +27,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
+#include <algorithm>
 #include <string.h>
 
 #define MAXID (INT_MAX/2)


### PR DESCRIPTION
Fix is required to compile with clang 19.
See https://github.com/NixOS/nixpkgs/issues/368973 and #42 